### PR TITLE
fix(loadtest): typos in script

### DIFF
--- a/web/test.py
+++ b/web/test.py
@@ -22,6 +22,6 @@ for i, (output, returncode) in enumerate(pool.imap(child, commands)):
        print("{} command failed: {}".format(i, returncode))
     else:
        print("{} success: {}".format(i, output))
-       times.append(float(output.split('=')[2]))
+       times.append(float(output.split(b'=')[2]))
 
-print 'Average: {}'.format(sum(times) / len(times) if times else 0)
+print('Average: {}'.format(sum(times) / len(times) if times else 0))


### PR DESCRIPTION
In order to `split` bytes, a `bytes` must object must also be provided.
There was also a typo in the print statement.